### PR TITLE
remove kopf from ES plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@
 * [Bigdesk](http://bigdesk.org/) - Live charts and statistics for elasticsearch cluster
 * [Elastic HQ](http://www.elastichq.org/) - Elasticsearch cluster management console with live monitoring and beautiful UI
 * [Cerebro](https://github.com/lmenezes/cerebro) is an open source(MIT License) elasticsearch web admin tool. Supports ES 5.x
-* [Kopf](https://github.com/lmenezes/elasticsearch-kopf) - Another management plugin that have REST console and *manual* shard allocation
 * [Search Guard](https://github.com/floragunncom/search-guard) - Elasticsearch security for free
 
 ### Other


### PR DESCRIPTION
as it is no longer maintained and their readme says cerebro might be better