### PR TITLE
Removed the link of sense-chrome plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
  
 ### Development and debugging
 * [Sense (from Elastic)](https://github.com/elastic/sense/#sense) A JSON aware developer console to Elasticsearch; official and very powerful
-* [Sense (Google Chrome extension)](https://chrome.google.com/webstore/detail/sense-beta/lhjgkmllcaadmopgmanpapmpjgmfcfig?hl=en) A JSON aware developer console to Elasticsearch; unofficial but very powerful
 * [ES-mode](https://github.com/dakrone/es-mode) An Emacs major mode for interacting with Elasticsearch (similar to Sense)
 * [Elasticsearch Cheatsheet](http://elasticsearch-cheatsheet.jolicode.com/) Examples for the most used queries, API and settings for all major version of Elasticsearch
 * [Elasticstat](https://github.com/objectrocket/elasticstat) CLI tool displaying monitoring informations like htop


### PR DESCRIPTION
Starting with Chrome 61, the old browser extension version of sense (https://github.com/elastic/sense172) was marked by Google as containing malware. It's been removed from the chrome webstore, and the browser forcibly disables the extension.