### PR TITLE
add certified engineer article

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 * [Elasticsearch in Action](https://www.manning.com/books/elasticsearch-in-action) - teaches you how to build scalable search applications using Elasticsearch (2015)
 * [Elasticsearch in Action, Second edition](https://www.manning.com/books/elasticsearch-in-action-second-edition) - hands-on guide to developing fully functional search engines with Elasticsearch and Kibana. (2021)
 
+## Certifications
+### Elastic Certified Engineer
+* [Elastic Certified Engineer notes](https://www.pistocop.dev/posts/es_engineer_exam_notes/) - notes and exercises to prepare the certification exam
+
 ## Related (awesome) lists
 * [frutik/awesome-search](https://github.com/frutik/awesome-search) I am building e-commerce search now. Below are listed some of my build blocks
 


### PR DESCRIPTION
I haven't found, during my studies, good and updated resources to prepare the [Elastic Certified Engineer Exam](https://www.elastic.co/training/elastic-certified-engineer-exam) (like [this](https://github.com/sathishvj/awesome-gcp-certifications) repository for the GCP exams).

I think this repository could be a good place to collect, together with the other resource, the notes/blogs/repositories useful for the Elasticsearch exams.

So I have added the Certification section, together with my notes to prepare the exam.
