### PR TITLE
Add link to Ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 
 * [Python Elasticsearch Client](https://elasticsearch-py.readthedocs.io/en/latest/) - Official low-level elasticsearch client for python
 * [Elasticsearch DSL](https://elasticsearch-dsl.readthedocs.io/en/latest/) - High-level python client for Elasticsearch
+* [Ruby Elasticsearch Client](https://github.com/elastic/elasticsearch-ruby) - Official low-level elasticsearch client for Ruby
 
 ### Development and debugging
 * [Sense (from Elastic)](https://github.com/elastic/sense/#sense) A JSON aware developer console to Elasticsearch; official and very powerful


### PR DESCRIPTION
Analogous to [this](https://github.com/dzharii/awesome-elasticsearch/pull/80) Python PR, but for Ruby