### PR TITLE
add DocKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 * [Sentinl](https://github.com/sirensolutions/sentinl) - Sentinl is a Kibana alerting and reporting app.
 * [Praeco](https://github.com/ServerCentral/praeco/) - Elasticsearch alerting made simple
 * [DataStation](https://github.com/multiprocessio/datastation) - Easily query, script, and visualize data from every database, file, and API.
+* [DocKit](https://github.com/geek-fun/dockit) - GUI client for elasticsearch to query, manage and visualize your data.
 
 
 ## Elasticsearch developer tools and utilities


### PR DESCRIPTION
DocKit is a desktop client to query, manage and visualize  elasticsearch server.

<img width="2032" alt="client-ui" src="https://github.com/user-attachments/assets/d66adfba-447d-4feb-8f29-370316199f5a">
